### PR TITLE
Prevented division by 0

### DIFF
--- a/src/com/isolation/portalhelper/SchoolClass.java
+++ b/src/com/isolation/portalhelper/SchoolClass.java
@@ -36,7 +36,7 @@ public class SchoolClass implements Serializable{
 			totalPoints += a.getPoints();
 			totalPossible += a.getPossible();
 		}
-		totalPercent = totalPoints / totalPossible;
+		totalPercent = totalPossible > 0 ? totalPoints / totalPossible : 1;
 	}
 	
 	public String toString(){


### PR DESCRIPTION
When the totalPossible points are 0 (beginning of quarter), the totalPercent defaults to 100%.