### PR TITLE
Avoided Division by 0

### DIFF
--- a/src/com/isolation/portalhelper/Assignment.java
+++ b/src/com/isolation/portalhelper/Assignment.java
@@ -39,7 +39,7 @@ public class Assignment implements Serializable{
 	}
 	public void setPossible(float p){
 		possible = p;
-		percent = points / possible;
+		percent = possible > 0 ? points / possible : 1;
 	}
 	public float getPercent() {
 		return percent;


### PR DESCRIPTION
Makes sure that the total possible points isn't 0. Not sure if this is possible, but avoided it anyway.